### PR TITLE
Update arducam_mipicamera.py: type error in function remove_padding (solves issue #36)

### DIFF
--- a/RPI/python/arducam_mipicamera.py
+++ b/RPI/python/arducam_mipicamera.py
@@ -2,6 +2,7 @@
 This script is a wrapper for the libarducam_mipicamera.so dynamic library. 
 To use this script you need to pre-install libarducam_mipicamera.so
 '''
+from __future__ import division
 from ctypes import *
 import numpy as np
 import sys
@@ -530,7 +531,7 @@ def unpack_mipi_raw10(byte_buf):
 
 def remove_padding(data, width, height, bit_width):
     buff = np.frombuffer(data, np.uint8)
-    real_width = width / 8 * bit_width
+    real_width = width // 8 * bit_width
     align_width = align_up(real_width, 32)
     align_height = align_up(height, 16)
     


### PR DESCRIPTION
solves issue #36: variable `real_width` has to be of type integer in order to be processed properly in function `align_up`. In Python 3 the division `width / 8` results in a floating point value (this is different in Python 2). The floor division `width // 8` assures that `real_width` is an integer in Python 3. The import line keeps compatibility of the code with Python 2 (should work there as well, not tested).