### PR TITLE
indication for i2c-bus on jetson xavier nx

### DIFF
--- a/Jetson/IMX219/FocuserExample.py
+++ b/Jetson/IMX219/FocuserExample.py
@@ -100,7 +100,7 @@ def parse_cmdline():
     parser = argparse.ArgumentParser(description='Arducam Controller.')
 
     parser.add_argument('-i', '--i2c-bus', type=int, nargs=None, required=True,
-                        help='Set i2c bus, for A02 is 6, for B01 is 7 or 8.')
+                        help='Set i2c bus, for A02 is 6, for B01 is 7 or 8, for Jetson Xavier NX it is 9 and 10.')
 
     return parser.parse_args()
 


### PR DESCRIPTION
to make autofocus work on Jetson Xavier NX (dev kit) , you need to use i2cset on bus 9 (for cam1) and bus 10(for cam2) on 0x0c so it will look like this 
`os.system("i2cset -y 9 0x0c %d %d" % (data1,data2)) `

<img width="362" alt="Screen Shot 2020-06-16 at 17 41 17" src="https://user-images.githubusercontent.com/6323038/84796169-a00a4800-aff8-11ea-80bf-1ca787650d3c.png">

you can also add this 

`return ('nvarguscamerasrc sensor-id=1 ! ' `
to update the sensor-id with gstream